### PR TITLE
Fix template tests to run under any RDF_PIPELINE_DEV_DIR path.

### DIFF
--- a/RDF-Pipeline/lib/RDF/Pipeline/Template.pm
+++ b/RDF-Pipeline/lib/RDF/Pipeline/Template.pm
@@ -57,6 +57,13 @@ use URI::Escape;
 ###################           MAIN            ####################
 ##################################################################
 
+# To allow for comparision on different RDF_PIPELINE_DEV_DIR paths in
+# our tests, we will strip the $RDF_PIPELINE_DEV_DIR env variable path 
+# if it is on  the caller script path.
+my $devDir = $ENV{RDF_PIPELINE_DEV_DIR} || "";
+my $escapeDevDir = quotemeta $devDir;
+my $callerScriptPath = $0 =~ s/$escapeDevDir/RDF_PIPELINE_DEV_DIR/r; 
+
 unless (caller) {
   # print "This is the script being executed\n";
   &GetArgsAndProcessTemplate();
@@ -120,7 +127,8 @@ $queryString ||= "";
 my $pVars;
 ($template, $pVars) = &ScanForList("parameters", $template);
 my $qsHash = &ParseQueryString($queryString);
-my $errorTemplate = "$0: [ERROR] Duplicate template variable: %s\n";
+
+my $errorTemplate = "$callerScriptPath: [ERROR] Duplicate template variable: %s\n";
 foreach (@{$pVars}) {
 	# Split param1=pVar1 if needed.
 	my ($param, $var) = split(/\=/, $_, 2);
@@ -211,9 +219,9 @@ $pRep ||= {};
 $pVars && $pVals or confess "$0: AddPairsToHash called with insufficient arguments\n";
 my $nVars = scalar(@{$pVars});
 my $nVals = scalar(@{$pVals});
-$nVars >= $nVals or die "$0: [ERROR] $nVals values provided for $nVars template variables (@{$pVars})\n";
+$nVars >= $nVals or die "$callerScriptPath: [ERROR] $nVals values provided for $nVars template variables (@{$pVars})\n";
 
-my $errorTemplate = "$0: [ERROR] duplicate template variable: %s\n";
+my $errorTemplate = "$callerScriptPath: [ERROR] duplicate template variable: %s\n";
 for (my $i=0; $i<@{$pVars}; $i++) {
 	die sprintf($errorTemplate, ${$pVars}[$i])
 		if $errorTemplate && exists($pRep->{${$pVars}[$i]});

--- a/RDF-Pipeline/t/run-test.perl
+++ b/RDF-Pipeline/t/run-test.perl
@@ -115,6 +115,8 @@ foreach my $tDir (@tDirs) {
 
   -e $wwwDir || mkdir($wwwDir) || die "ERROR: Failed to mkdir $wwwDir\n";
 
+  !system("$devDir/tools/flush-caches") || die "ERROR: Cannot flush cache";
+
   ### If there is a "setup-files" directory, then use it.
   my $setupFiles = "$tDir/setup-files";
   if (-d $setupFiles) {

--- a/RDF-Pipeline/t/tests/0032_Duplicate_Template_Variable/expected-files/test/sample-template-expanded.txt
+++ b/RDF-Pipeline/t/tests/0032_Duplicate_Template_Variable/expected-files/test/sample-template-expanded.txt
@@ -1,1 +1,1 @@
-/home/dbooth/rdf-pipeline/trunk/tools/ste.perl: [ERROR] duplicate template variable: $inUri
+RDF_PIPELINE_DEV_DIR/tools/ste.perl: [ERROR] duplicate template variable: $inUri

--- a/RDF-Pipeline/t/tests/0033_Duplicate_Template_Variable2/expected-files/test/sample-template-expanded.txt
+++ b/RDF-Pipeline/t/tests/0033_Duplicate_Template_Variable2/expected-files/test/sample-template-expanded.txt
@@ -1,1 +1,1 @@
-/home/dbooth/rdf-pipeline/trunk/tools/ste.perl: [ERROR] Duplicate template variable: $max
+RDF_PIPELINE_DEV_DIR/tools/ste.perl: [ERROR] Duplicate template variable: $max

--- a/RDF-Pipeline/t/tests/0034_Too_many_template_values/expected-files/test/sample-template-expanded.txt
+++ b/RDF-Pipeline/t/tests/0034_Too_many_template_values/expected-files/test/sample-template-expanded.txt
@@ -1,1 +1,1 @@
-/home/dbooth/rdf-pipeline/trunk/tools/ste.perl: [ERROR] 3 values provided for 2 template variables ($inUri Bill)
+RDF_PIPELINE_DEV_DIR/tools/ste.perl: [ERROR] 3 values provided for 2 template variables ($inUri Bill)

--- a/RDF-Pipeline/t/tests/0049_DependsOn_clock_site/test-script
+++ b/RDF-Pipeline/t/tests/0049_DependsOn_clock_site/test-script
@@ -22,10 +22,16 @@ $ENV{RDF_PIPELINE_WWW_DIR} = $wwwDir;
 ############ CUSTOMIZE HERE ################
 # This test appends to hellos.txt, so clear it out first:
 unlink "node/hellos.txt";
+
 # Invoke the URL, concatenating its output to $wwwDir/test/testout :
 my $testUrl = 'http://localhost/node/hello';
+
 # Requesting the first time should produce ONE line of "hello" output:
 !system("../../helpers/pipeline-request.perl GET '$testUrl'") or die;
+
+# sleep for a second to let the time update
+sleep(1);
+
 # Requesting the second time should produce TWO lines of "hello" output:
 !system("../../helpers/pipeline-request.perl GET '$testUrl'") or die;
 ############################################


### PR DESCRIPTION
Fix template tests to run under any RDF_PIPELINE_DEV_DIR path.

Also
    1. fixed test 0037 to handle tmp dir correctly
    2. added 1 sec delay so 0049 passes consistently
    3. apply David's ordering changes
    4. Clear system between tests
